### PR TITLE
Replaces call to deprecated function.

### DIFF
--- a/wp-ses.php
+++ b/wp-ses.php
@@ -87,7 +87,7 @@ function wpses_install() {
 function wpses_options() {
     global $wpdb, $wpses_options;
     global $current_user;
-    get_currentuserinfo();
+    wp_get_current_user();
     if (!in_array('administrator', $current_user->roles)) {
         //die('Pas admin');
     }


### PR DESCRIPTION
get_currentuserinfo() has been deprecated by WordPress. This PR replaces the call to get_currentuserinfo() on line 90 of the main plugin file with the current preferred method, wp_get_current_user().